### PR TITLE
Correct Run to Future docs and provide an example

### DIFF
--- a/docs/guides/interop/with-future.md
+++ b/docs/guides/interop/with-future.md
@@ -51,4 +51,14 @@ def fiberToFuture[A](fiber: Fiber[Throwable, A]): UIO[Future[A]] =
 
 ## Run to Future
 
-The `Runtime` type has a method `unsafeRunToFuture`, which can execute a ZIO effect asynchronously, and return a `Future` that will be completed when the execution of the effect is complete.
+You can call `.unsafe.runToFuture` on an instance of `Runtime` to execute a ZIO effect asynchronously and return a `Future` that will be completed when the execution of the effect is complete.
+
+```scala
+import zio.{Runtime, Task, Unsafe}
+...
+val zio: Task[String] = ...
+val runtime = Runtime.default
+val fut: Future[String] = Unsafe.unsafe { implicit unsafe =>
+  runtime.unsafe.runToFuture(zio)
+}
+```


### PR DESCRIPTION
The documentation referenced a non-existent method.